### PR TITLE
[BUG] Fix css style loading when entering the page using a subpath

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -1,3 +1,4 @@
 @import 'tailwindcss/base';
 @import 'tailwindcss/components';
 @import 'tailwindcss/utilities';
+@import '/src/css/basic-styles.css';


### PR DESCRIPTION
Basically when the user tries to enter the page using a subpath, some layouts used in the file `/src/routes/+layout.svelte` are imported to have "context" for the page to get some global css styles, the main file was missing in the import that this file does (it imports `app.css`).